### PR TITLE
feat(PQRCardAttachments): add autoPlay with muted for videos and handle undefined attachments

### DIFF
--- a/components/pqr/components/PQRCardAttachments.tsx
+++ b/components/pqr/components/PQRCardAttachments.tsx
@@ -16,7 +16,17 @@ type PQRCardAttachmentsProps = {
   isMobile?: boolean;
 };
 
-export function PQRCardAttachments({ attachments, videoRefsDesktop, videoRefsMobile, isMobile = false }: PQRCardAttachmentsProps) {
+export function PQRCardAttachments({
+  attachments = [],
+  videoRefsDesktop,
+  videoRefsMobile,
+  isMobile = false,
+}: PQRCardAttachmentsProps) {
+  if (!Array.isArray(attachments)) {
+    console.error("attachments no es un array:", attachments);
+    return null;
+  }
+
   const imageAttachments = attachments.filter((att) =>
     mediaExtensions.includes(att.type.toLowerCase())
   );
@@ -45,6 +55,8 @@ export function PQRCardAttachments({ attachments, videoRefsDesktop, videoRefsMob
                         src={attachment.url}
                         className="object-cover w-full h-full"
                         controls
+                        autoPlay
+                        muted
                       />
                     </div>
                   ) : (

--- a/components/pqr/hooks/useVideoPlayback.ts
+++ b/components/pqr/hooks/useVideoPlayback.ts
@@ -9,12 +9,12 @@ export function useVideoPlayback() {
     const handleScroll = () => {
       videoRefsDesktop.current.forEach((video) => {
         if (video && !video.paused) {
-          video.pause();
+          video.muted = true;
         }
       });
       videoRefsMobile.current.forEach((video) => {
         if (video && !video.paused) {
-          video.pause();
+          video.muted = true;
         }
       });
     };

--- a/services/api/pqr.service.ts
+++ b/services/api/pqr.service.ts
@@ -7,7 +7,7 @@ const Client = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-  timeout: 30000, 
+  timeout: 10000, 
 });
 
 type createPQRS = {


### PR DESCRIPTION
- Added `autoPlay` and `muted` attributes to video elements to enable automatic playback in supported browsers.
- Added a default value and validation for `attachments` prop to prevent `TypeError` when `attachments` is undefined or not an array.