### PR TITLE
feat(notifications): add Expo push token support and push sending

### DIFF
--- a/app/api/push-token/route.ts
+++ b/app/api/push-token/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { currentUser } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  const user = await currentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { token } = await req.json();
+  if (!token || typeof token !== "string") {
+    return NextResponse.json({ error: "Token requerido" }, { status: 400 });
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { pushToken: token },
+  });
+
+  return NextResponse.json({ success: true });
+}
+
+export async function DELETE(req: NextRequest) {
+  const user = await currentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { pushToken: null },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,8 @@ model User {
   following         User[]              @relation("UserFollows")
   followers         User[]              @relation("UserFollows")
   
+  pushToken         String?
+
   // NextAuth.js relations
   accounts          Account[]
   entityResponses   EntityResponse[]

--- a/services/api/notification.service.ts
+++ b/services/api/notification.service.ts
@@ -2,6 +2,33 @@
 import { CreateNotificationInput } from '@/types/notification';
 import prisma from "@/lib/prisma";
 
+const NOTIFICATION_TITLES: Record<string, string> = {
+  like: "Nuevo me gusta",
+  comment: "Nuevo comentario",
+  follow: "Nuevo seguidor",
+  pqrsd_time_expired: "PQRSD vencida",
+  lawyer_request_accepted: "Solicitud de asesoría aceptada",
+  lawyer_request_rejected: "Solicitud de asesoría rechazada",
+  new_lawyer_request: "Nueva solicitud de asesoría",
+};
+
+async function sendExpoPush(
+  token: string,
+  title: string,
+  body: string,
+  data: Record<string, string>
+) {
+  try {
+    await fetch("https://exp.host/--/api/v2/push/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ to: token, title, body, data }),
+    });
+  } catch (error) {
+    console.error("Error sending Expo push notification:", error);
+  }
+}
+
 export const NotificationFactory = {
   createFollow: (
     userId: string, 
@@ -130,9 +157,22 @@ export const NotificationFactory = {
 
 export const notificationService = {
   async create(notificationInput: CreateNotificationInput) {
-    return await prisma.notification.create({
+    const notification = await prisma.notification.create({
       data: notificationInput,
     });
+
+    const user = await prisma.user.findUnique({
+      where: { id: notificationInput.userId },
+      select: { pushToken: true },
+    });
+
+    if (user?.pushToken) {
+      const title = NOTIFICATION_TITLES[notificationInput.type] ?? "Nueva notificación";
+      const data = (notificationInput.data ?? {}) as Record<string, string>;
+      await sendExpoPush(user.pushToken, title, notificationInput.message, data);
+    }
+
+    return notification;
   },
 
   async markAsRead(notificationId: string) {


### PR DESCRIPTION
- Add pushToken field to User model in Prisma schema
- Add POST /api/push-token endpoint to register device token (upsert)
- Add DELETE /api/push-token endpoint to clear token on logout
- Update notificationService.create() to send Expo push notification after saving to DB, including data.pqrId/userId/requestId for deep linking