### PR TITLE
fix(privacy): stop exposing creator password hash and contact data

### DIFF
--- a/app/api/pqr/[id]/privacy/route.ts
+++ b/app/api/pqr/[id]/privacy/route.ts
@@ -50,7 +50,10 @@ export async function PATCH(
         updatedAt: new Date()
       },
       include: {
-        creator: true,
+        // Nunca la fila User completa: traía el hash bcrypt de la contraseña.
+        creator: {
+          select: { id: true, name: true, image: true },
+        },
         customFieldValues: true
       }
     });

--- a/app/api/pqr/[id]/route.ts
+++ b/app/api/pqr/[id]/route.ts
@@ -51,7 +51,12 @@ export async function GET(
           },
         },
         customFieldValues: true,
-        creator: true,
+        // `creator: true` devolvía TODA la fila User —incluido el hash bcrypt de
+        // la contraseña, el correo y el teléfono— y este endpoint es PÚBLICO
+        // para las PQRSD no privadas. Solo los campos que los clientes leen.
+        creator: {
+          select: { id: true, name: true, image: true },
+        },
         statusHistory: {
           select: {
             id: true,

--- a/app/api/pqr/[id]/status/route.ts
+++ b/app/api/pqr/[id]/status/route.ts
@@ -51,7 +51,10 @@ export async function PATCH(
       },
       include: {
         department: true,
-        creator: true,
+        // Nunca la fila User completa: traía el hash bcrypt de la contraseña.
+        creator: {
+          select: { id: true, name: true, image: true },
+        },
         customFieldValues: true
       }
     });

--- a/app/api/pqr/route.ts
+++ b/app/api/pqr/route.ts
@@ -319,7 +319,11 @@ export async function POST(req: NextRequest) {
           entity: true,
           customFieldValues: true,
           attachments: true,
-          creator: true,
+          // Nunca la fila User completa: traía el hash bcrypt de la contraseña.
+          // Los correos de notificación usan sus propias consultas más abajo.
+          creator: {
+            select: { id: true, name: true, image: true },
+          },
         },
       }),
       prisma.entityConsecutive.update({

--- a/app/api/pqr/top/route.ts
+++ b/app/api/pqr/top/route.ts
@@ -4,6 +4,12 @@ import prisma from "@/lib/prisma";
 export async function GET() {
   try {
     const topPQRs = await prisma.pQRS.findMany({
+      // Mismo filtro que el muro público: una PQRSD privada no puede aparecer
+      // en un ranking público con su asunto, descripción y autor.
+      where: {
+        private: false,
+        creatorId: { not: null },
+      },
       take: 3,
       orderBy: {
         likes: {

--- a/app/api/pqr/user/[id]/route.ts
+++ b/app/api/pqr/user/[id]/route.ts
@@ -58,7 +58,8 @@ export async function GET(request: Request, params: any) {
             id: true,
             name: true,
             image: true,
-            email: true,
+            // Sin `email`: endpoint público, y el correo es dato personal
+            // (Ley 1581). Ningún cliente lo lee de aquí.
           }
         }
       },


### PR DESCRIPTION
`include: { creator: true }` returns every scalar field of the related User row -- including the bcrypt `password` hash, `email` and `phone`. `GET /api/pqr/:id` is public for non-private PQRSD (the privacy gate only runs `if (pqr.private)`), so anyone could read a citizen's password hash by fetching a complaint whose id the public list already hands out.

The creator relation is now selected explicitly as `{id, name, image}` -- the only fields any client actually reads (verified against the web and the mobile app). The notification emails are unaffected: they build their contact data from their own queries with explicit selects, not from these responses.

Also:
- Drop `creator.email` from `GET /pqr/user/:id`, a public endpoint.
- Filter `GET /pqr/top` by `private: false` and `creatorId != null`, same as the public wall. Without it a private complaint could surface in a public ranking along with its subject, description and author.