### PR TITLE
fix(security): require a session to upload files

### DIFF
--- a/app/api/upload/presigned/route.ts
+++ b/app/api/upload/presigned/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { randomUUID } from 'crypto'
+import { currentUser } from '@/lib/auth'
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION!,
@@ -13,6 +14,16 @@ const s3Client = new S3Client({
 
 export async function POST(request: Request) {
   try {
+    // #6: firmar una subida exige sesión (cookie web o Bearer móvil). Sin esto
+    // cualquiera en internet podía pedir una URL prefirmada y escribir en el
+    // bucket, con lectura pública, sin límite de tamaño y eligiendo la ruta.
+    // Crear una PQRSD ya exige sesión (#5), así que no hay ningún flujo
+    // legítimo de subida anónima.
+    const authUser = await currentUser()
+    if (!authUser?.id) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    }
+
     const { filename, contentType, folder = 'uploads' } = await request.json()
 
     // if (!ALLOWED_MIME_TYPES.includes(contentType)) {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from "next/server";
 import { uploadObject } from "@/services/storage/s3.service";
 import { AWS_BUCKET, AWS_REGION } from "@/lib/config";
+import { currentUser } from "@/lib/auth";
 
 export async function POST(request: Request) {
   try {
+    // #6: subir un fichero exige sesión (cookie web o Bearer móvil). Sin esto
+    // cualquiera en internet podía escribir directamente en el bucket, con
+    // lectura pública y sin límite de tamaño. Crear una PQRSD ya exige sesión
+    // (#5), así que no hay ningún flujo legítimo de subida anónima.
+    const authUser = await currentUser();
+    if (!authUser?.id) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
     const data = await request.formData();
     const file: File | null = data.get("file") as unknown as File;
 


### PR DESCRIPTION
Both upload endpoints accepted anonymous requests: anyone could obtain a presigned URL or push a file straight into the bucket, world-readable and with no size limit. Creating a PQRSD already requires a session (#5), so no legitimate unauthenticated upload path exists.

`currentUser()` accepts both the web cookie and the mobile Bearer token, so the published clients keep working unchanged.

Scope is deliberately limited to authentication. MIME allowlisting, folder validation and size caps are already implemented in the new backend and arrive when the clients are repointed; adding them here would risk breaking the published mobile app for a smaller gain.